### PR TITLE
Feature/version - adding __version__ attribute.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,10 @@
 try:
     from . import mrob
 
+    from pkg_resources import get_distribution
+
+    __version__ = get_distribution('mrob').version
+
     for module in dir(mrob):
         n = len(module) - 1
         if not (module[:2] == '__' and module[n:n-2:-1] == '__') and module.count('.') == 0:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,12 @@
 [metadata]
 name = mrob
 home-page = https://github.com/MobileRoboticsSkoltech/mrob
+author = Gonzalo Ferrer
+author_email = G.Ferrer@skoltech.ru
+url = https://github.com/MobileRoboticsSkoltech/mrob
+download_url = https://github.com/MobileRoboticsSkoltech/mrob
+description = The Skoltech Mobile Robotics library (mrob) is a framework for implementing robotics research and projects.
+platforms = any
 maintainer = Gonzalo Ferrer
 maintainer_email = G.Ferrer@skoltech.ru
 long-description = file: README.md

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,11 @@ try:
 except ImportError:
     bdist_wheel = None
 
-
 setuptools.setup(
-    version_config=True,
+    version_config={
+        "dev_template": "{tag}.{branch}.post{ccount}+git.{sha}",
+        "dirty_template": "{tag}.{branch}.post{ccount}+git.{sha}.dirty",
+    },
+    setup_requires=['setuptools-git-versioning'],
     cmdclass={'bdist_wheel': bdist_wheel}
 )


### PR DESCRIPTION
Metadata for mrob improved:

- branch added into the version value + possible to set full SHA value if required (setuptools-git-versioning);
- summary added;
- author and author e-mail added;
- download URL added;
- supported platforms added = 'any';

**Before:**
![Screenshot from 2021-11-08 01-30-30](https://user-images.githubusercontent.com/22825575/140664970-024e183e-c0a6-4d28-b746-d03a8184bd3c.png)

**Now:**
![Screenshot from 2021-11-08 01-21-53](https://user-images.githubusercontent.com/22825575/140664951-4739e5b2-1ba9-4e79-ba6b-5b8c220d0677.png)

MROB package now has attribute version that can be called from the console line.

![Screenshot from 2021-11-08 01-49-07](https://user-images.githubusercontent.com/22825575/140664938-0e5020a5-6a4e-4af8-915f-83a3f8196097.png)

